### PR TITLE
Added the print logs properties

### DIFF
--- a/pathstore/src/main/java/pathstore/common/Constants.java
+++ b/pathstore/src/main/java/pathstore/common/Constants.java
@@ -61,7 +61,7 @@ public final class Constants {
     public static final String APPLICATION_NAME = "applicationName";
     public static final String APPLICATION_MASTER_PASSWORD = "applicationMasterPassword";
     public static final String REGISTRY_IP = "registryIP";
-    public static final String SAVE_LOGS = "saveLogs";
+    public static final String PRINT_LOGS = "printLogs";
     public static final String PATHSTORE_VERSION = "pathstoreVersion";
   }
 

--- a/pathstore/src/main/java/pathstore/common/PathStoreProperties.java
+++ b/pathstore/src/main/java/pathstore/common/PathStoreProperties.java
@@ -21,6 +21,7 @@ import lombok.ToString;
 import pathstore.authentication.credentials.NodeCredential;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Properties;
 
 import static pathstore.common.Constants.PROPERTIESFILE;
@@ -189,10 +190,11 @@ public class PathStoreProperties {
   public String registryIP = null;
 
   /**
-   * Indicates whether logs should be saved to the database. For example, you might need to disable it
-   * for experiments related to performance and bandwidth consumption
+   * Indicates whether logs should be printed or not. This is a client side only feature.
+   * Our client side driver will print logs related to grpc calls and other interactions that the client may
+   * wish to display via their properties file.
    */
-  public boolean saveLogs = true;
+  public boolean printLogs = true;
 
   /** This string is to denote the pathstore version used */
   public String pathstoreVersion = null;
@@ -237,17 +239,20 @@ public class PathStoreProperties {
           this.sessionFile = this.getProperty(props, SESSION_FILE);
           this.applicationName = this.getProperty(props, APPLICATION_NAME);
           this.applicationMasterPassword = this.getProperty(props, APPLICATION_MASTER_PASSWORD);
-          this.saveLogs = Boolean.parseBoolean(this.getProperty(props, SAVE_LOGS, "true"));
+          this.printLogs = Boolean.parseBoolean(this.getProperty(props, PRINT_LOGS, "true"));
           break;
         default:
           throw new Exception();
       }
 
       in.close();
-    } catch (Exception ex) {
-      System.err.println("Error parsing properties file with the stack trace:");
-      ex.printStackTrace();
-      System.exit(1);
+    } catch (IOException ex) {
+        System.err.println("Error parsing properties file with the stack trace:");
+        ex.printStackTrace();
+        System.exit(1);
+    }catch (Exception e){
+        System.err.println("You must provide a role out of (CLIENT, SERVER, ROOTSERVER)");
+        System.exit(1);
     }
   }
 

--- a/pathstore/src/main/java/pathstore/system/PathStoreServerImpl.java
+++ b/pathstore/src/main/java/pathstore/system/PathStoreServerImpl.java
@@ -23,7 +23,10 @@ import io.grpc.ServerBuilder;
 import pathstore.authentication.CredentialCache;
 import pathstore.authentication.grpc.AuthManager;
 import pathstore.authentication.grpc.AuthServerInterceptor;
-import pathstore.common.*;
+import pathstore.common.Constants;
+import pathstore.common.PathStoreProperties;
+import pathstore.common.PathStoreThreadManager;
+import pathstore.common.Role;
 import pathstore.grpc.*;
 import pathstore.system.deployment.deploymentFSM.PathStoreDeploymentUtils;
 import pathstore.system.deployment.deploymentFSM.PathStoreMasterDeploymentServer;
@@ -161,7 +164,8 @@ public class PathStoreServerImpl {
     PathStoreThreadManager daemonManager = PathStoreThreadManager.getDaemonInstance();
     daemonManager
         .spawn(new PathStoreSlaveDeploymentServer())
-        .spawn(new PathStoreSlaveSchemaServer());
+        .spawn(new PathStoreSlaveSchemaServer())
+        .spawn(new PathStoreLoggerDaemon());
 
     if (PathStoreProperties.getInstance().role != Role.ROOTSERVER)
       daemonManager.spawn(new PathStorePushServer()).spawn(new PathStorePullServer());
@@ -169,8 +173,5 @@ public class PathStoreServerImpl {
       daemonManager
           .spawn(new PathStoreMasterDeploymentServer())
           .spawn(new PathStoreMasterSchemaServer());
-
-    if (PathStoreProperties.getInstance().saveLogs)
-      daemonManager.spawn(new PathStoreLoggerDaemon());
   }
 }

--- a/pathstore/src/main/java/pathstore/system/deployment/commands/GeneratePropertiesFile.java
+++ b/pathstore/src/main/java/pathstore/system/deployment/commands/GeneratePropertiesFile.java
@@ -96,7 +96,7 @@ public class GeneratePropertiesFile implements ICommand {
     properties.put(USERNAME, this.username);
     properties.put(PASSWORD, this.password);
     properties.put(REGISTRY_IP, this.registryIP);
-    properties.put(SAVE_LOGS, String.valueOf(true));
+    properties.put(PRINT_LOGS, String.valueOf(true));
     properties.put(PATHSTORE_VERSION, this.pathstoreVersion);
 
     try {

--- a/pathstore/src/main/java/pathstore/system/logging/PathStoreLogger.java
+++ b/pathstore/src/main/java/pathstore/system/logging/PathStoreLogger.java
@@ -2,6 +2,7 @@ package pathstore.system.logging;
 
 import lombok.RequiredArgsConstructor;
 import pathstore.common.PathStoreProperties;
+import pathstore.common.Role;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -91,12 +92,14 @@ public class PathStoreLogger {
    * @param message what message to print
    */
   public void log(final LoggerLevel loggerLevel, final String message) {
+    if (!PathStoreProperties.getInstance().printLogs) return;
+
     int count = counter.getAndIncrement();
 
     PathStoreLoggerMessage loggerMessage =
-            new PathStoreLoggerMessage(count, loggerLevel, message, this.name);
+        new PathStoreLoggerMessage(count, loggerLevel, message, this.name);
 
-    if (PathStoreProperties.getInstance().saveLogs) {
+    if (PathStoreProperties.getInstance().role != Role.CLIENT) {
       this.hasNew = true;
 
       this.messages.put(count, loggerMessage);


### PR DESCRIPTION
I added a properties variable called `printLogs`. If false, the logger daemon will not start and the log messages will not be appended to the queue either. The default value is true