### PR TITLE
added simple 'all' and 'one' implementations for compatibility issues

### DIFF
--- a/pathstore/src/main/java/pathstore/client/PathStoreResultSet.java
+++ b/pathstore/src/main/java/pathstore/client/PathStoreResultSet.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -95,9 +96,8 @@ public class PathStoreResultSet implements ResultSet {
     throw new UnsupportedOperationException();
   }
 
-  // TODO: Myles: We need to implement this
   public List<Row> all() {
-    throw new UnsupportedOperationException();
+  	return this.stream().collect(Collectors.toList());
   }
 
   /**
@@ -138,7 +138,7 @@ public class PathStoreResultSet implements ResultSet {
    */
   public Row one() {
     if (this.table.startsWith(Constants.LOCAL_PREFIX)) return resultSet.one();
-    throw new UnsupportedOperationException();
+    return this.stream().findFirst().orElse(null);
   }
 
   /**


### PR DESCRIPTION
The lack of support for Cassandra result set's `.all()` and `.one()` is a major compatibility issue with our system. This PR aims to solve it